### PR TITLE
fix: added check for empty strings in response

### DIFF
--- a/data-tag.js
+++ b/data-tag.js
@@ -118,6 +118,9 @@ function dataTagSendData(data, gtmServerDomain, requestPath, dataLayerEventName,
             if(responseText && responseText.startsWith("event: message\ndata: ")) {
               responseText
                 .split("\n\n")
+                .filter(function(eventString) {
+                  return eventString;  // Filter out empty strings
+                })
                 .forEach(function(eventString) {
                   try {
                     const event =  JSON.parse(eventString.replace('event: message\ndata: ', ''));


### PR DESCRIPTION
This fix removes unnecessary console errors created by parsing the response string. It filters the split string to remove any empty strings from being included in the loop to process the response data. 

Note: this is a PR into Main as I branched from main, which seems to have more commits/content. Be sure to change to Dev for testing/if necessary. 