### PR TITLE
added missing page_path parameter

### DIFF
--- a/template.js
+++ b/template.js
@@ -182,6 +182,7 @@ function addCommonDataForPostRequest(data, eventData) {
 
 function addCommonData(data, eventData) {
   eventData.page_location = getUrl();
+  eventData.page_path = getUrl('path');
   eventData.page_hostname = getUrl('host');
   eventData.page_referrer = getReferrerUrl();
   eventData.page_title = readTitle();


### PR DESCRIPTION
The description of the feature "add common data" says it adds `page_path`, which was missing.