### PR TITLE
load_data_tag_script_url from template fields parameterizable

### DIFF
--- a/template.js
+++ b/template.js
@@ -31,8 +31,11 @@ const userAndCustomData = getUserAndCustomDataArray();
 let requestType = determinateRequestType();
 
 if (requestType === 'post') {
+  const dataScriptVersion = 'v7';
   const dataTagScriptUrl =
-    data.load_data_tag_script_url || 'https://cdn.stape.io/dtag/v7.js';
+      typeof data.load_data_tag_script_url !== 'undefined'
+          ? data.load_data_tag_script_url.replace('${data-script-version}', dataScriptVersion)
+          : 'https://cdn.stape.io/dtag/' + dataScriptVersion + '.js';
   injectScript(
     dataTagScriptUrl,
     sendPostRequest,

--- a/template.tpl
+++ b/template.tpl
@@ -533,7 +533,7 @@ ___TEMPLATE_PARAMETERS___
         "name": "load_data_tag_script_url",
         "displayName": "Data Tag Script URL",
         "simpleValueType": true,
-        "help": "Url, where to load data tag script from, by default will be loaded from https://cdn.stape.io/dtag/v6.js",
+        "help": "Url, where to load data tag script from, by default will be loaded from https://cdn.stape.io/dtag/${data-script-version}.js. This can be parameterized with ${data-script-version} in order to load the correct version for this tag.",
         "valueValidators": [
           {
             "type": "REGEX",
@@ -705,8 +705,11 @@ const userAndCustomData = getUserAndCustomDataArray();
 let requestType = determinateRequestType();
 
 if (requestType === 'post') {
+  const dataScriptVersion = 'v7';
   const dataTagScriptUrl =
-    data.load_data_tag_script_url || 'https://cdn.stape.io/dtag/v7.js';
+      typeof data.load_data_tag_script_url !== 'undefined'
+          ? data.load_data_tag_script_url.replace('${data-script-version}', dataScriptVersion)
+          : 'https://cdn.stape.io/dtag/' + dataScriptVersion + '.js';
   injectScript(
     dataTagScriptUrl,
     sendPostRequest,


### PR DESCRIPTION
Hi.

we’re hosting our own tagmanager infrastructure and are currently using your client/tag solution to get data to our server containers so first thanks for the effort and for providing these scripts!
 
However in our environment we have the requirement to not load any resources from foreign sources (including the stape cdn), so we’re hosting our own version of the ‘dataTagScript’. And as we don't monitor the releases of the data-tag/data-client we decouple from the your update cycle so that the coupling of data-tag.js and template.js does not eventually break our if a new template script is not compatible with an old configured data-tag.js script. 

So the question is, what were the benefits of externalizing the data-tag.js and only load it only requestType post? Is it for performance reasons? 

Would it be an option for you to simply include this part of the functionality in the template script code?
 
If not, would you consider a change similar to this pull request? Here the load_data_tag_script_url from the template fields can be parameterized with the data-script-version so that if one would build a mechanism to load the correct one compatibility would be maintained and we don't need to effectively fork your script.

Regards
Alex
 