### PR TITLE
Custom load data tag script function

### DIFF
--- a/data-tag-load.js
+++ b/data-tag-load.js
@@ -1,0 +1,80 @@
+/**
+ * This snippet is to be used as content of a custom javascript tag, triggered on initialization.
+ * It defines a function that the Data Tag can use to load its data tag script
+ * so users of the Data Tag can change the source of the data tag script to
+ * their own domain without having to touch the Data Tag template
+ */
+
+/**
+ * The URL pattern where the data tag script can be loaded from
+ * TODO: Replace the value with YOUR URL pattern
+ */
+var DATA_TAG_SCRIPT_URL_PATTERN = "https://cdn.stape.io/dtag/${data-script-version}.js";
+
+/**
+ * Function to load the data tag script
+ * @param version The version of the script to load (defined by the Data Tag).
+ * @param successCallback A callback to be run after the script loaded succeeded and with every call of this function afterwards.
+ * @param errorCallback A callback to be run if the script fails to load. It will be called with an error as parameter.
+ */
+function loadDataTagScript(version, successCallback, errorCallback) {
+  try {
+    var dataTagScriptId = "dataTagScript-version-".concat(version);
+    var existingScriptElement = document.getElementById(dataTagScriptId);
+    var scriptFinishedLoading = existingScriptElement && existingScriptElement.hasAttribute("data-finishedLoading");
+    var scriptLoadedSuccessfully = existingScriptElement && scriptFinishedLoading && typeof window.dataTagSendData !== "undefined";
+
+    if (scriptLoadedSuccessfully) {
+      if (successCallback) {
+        successCallback();
+      }
+      return;
+    } else if (existingScriptElement && scriptFinishedLoading) {
+      if (errorCallback) {
+        errorCallback(new Error("Failed to load/execute data tag script with version: ".concat(version)));
+      }
+      return;
+    }
+
+    deferCallbacks();
+
+    if (existingScriptElement && !scriptFinishedLoading) {
+      return;
+    }
+
+    var script = document.createElement("script");
+    script.id = dataTagScriptId;
+    var source = DATA_TAG_SCRIPT_URL_PATTERN.replace("${data-script-version}", version);
+    script.src = source;
+
+    script.onload = function() {
+      script.setAttribute("data-finishedLoading", true);
+      callDeferredCallbacks();
+    };
+    script.onerror = function() {
+      script.setAttribute("data-finishedLoading", true);
+      callDeferredCallbacks(new Error("Failed to load data tag script with version: ".concat(version)));
+    };
+    document.head.appendChild(script);
+  } catch (error) {
+    console.error("Error in myFunction:", error.message);
+  }
+  function deferCallbacks() {
+    window.dataTagScriptCallbacks = window.dataTagScriptCallbacks || {};
+    window.dataTagScriptCallbacks[version] = window.dataTagScriptCallbacks[version] || [];
+    window.dataTagScriptCallbacks[version].push({ successCallback: successCallback, errorCallback: errorCallback });
+  }
+  function callDeferredCallbacks(error) {
+    window.dataTagScriptCallbacks[version].forEach(function(callbackEntry) {
+      if (error) {
+        if (callbackEntry.errorCallback)
+          callbackEntry.errorCallback(error);
+      } else {
+        if (callbackEntry.successCallback)
+          callbackEntry.successCallback();
+      }
+    });
+    window.dataTagScriptCallbacks[version] = [];
+  }
+}
+

--- a/template.js
+++ b/template.js
@@ -32,19 +32,12 @@ let requestType = determinateRequestType();
 
 if (requestType === 'post') {
   const dataScriptVersion = 'v8';
-  const dataTagScriptUrl =
-    typeof data.load_data_tag_script_url !== 'undefined'
-      ? data.load_data_tag_script_url.replace(
-          '${data-script-version}',
-          dataScriptVersion
-        )
-      : 'https://cdn.stape.io/dtag/' + dataScriptVersion + '.js';
-  injectScript(
-    dataTagScriptUrl,
-    sendPostRequest,
-    data.gtmOnFailure,
-    dataTagScriptUrl
-  );
+  if (data.customLoadDataTagScriptFunction) {
+    callInWindow('loadDataTagScript', dataScriptVersion, sendPostRequest, data.gtmOnFailure);
+  } else {
+    const dataTagScriptUrl = 'https://cdn.stape.io/dtag/' + dataScriptVersion + '.js';
+    injectScript(dataTagScriptUrl, sendPostRequest, data.gtmOnFailure, dataTagScriptUrl);
+  }
 } else {
   sendGetRequest();
 }

--- a/template.tpl
+++ b/template.tpl
@@ -529,21 +529,11 @@ ___TEMPLATE_PARAMETERS___
         ]
       },
       {
-        "type": "TEXT",
-        "name": "load_data_tag_script_url",
-        "displayName": "Data Tag Script URL",
+        "type": "CHECKBOX",
+        "name": "customLoadDataTagScriptFunction",
+        "checkboxText": "Load data tag script with custom function",
         "simpleValueType": true,
-        "help": "Url, where to load data tag script from, by default will be loaded from https://cdn.stape.io/dtag/${data-script-version}.js. This can be parameterized with ${data-script-version} in order to load the correct version for this tag.",
-        "valueValidators": [
-          {
-            "type": "REGEX",
-            "args": [
-              "^(https://).*(\\.js)$"
-            ]
-          }
-        ],
-        "alwaysInSummary": false,
-        "defaultValue": "https://cdn.stape.io/dtag/v8.js"
+        "help": "Option to load the dataTagScript using a custom implementation of Data Tag users instead of the gtm injectScript function. If checked the Data Tag expects a function loadDataTagScript to be defined that takes three parameters: version (the version of the script to load), successCallback (function to execute on success), errorCallback (function to execute on failure). See the Data Tag repository for an implementation that you can use."
       },
       {
         "type": "CHECKBOX",
@@ -706,16 +696,12 @@ let requestType = determinateRequestType();
 
 if (requestType === 'post') {
   const dataScriptVersion = 'v8';
-  const dataTagScriptUrl =
-      typeof data.load_data_tag_script_url !== 'undefined'
-          ? data.load_data_tag_script_url.replace('${data-script-version}', dataScriptVersion)
-          : 'https://cdn.stape.io/dtag/' + dataScriptVersion + '.js';
-  injectScript(
-    dataTagScriptUrl,
-    sendPostRequest,
-    data.gtmOnFailure,
-    dataTagScriptUrl
-  );
+  if (data.customLoadDataTagScriptFunction) {
+    callInWindow('loadDataTagScript', dataScriptVersion, sendPostRequest, data.gtmOnFailure);
+  } else {
+    const dataTagScriptUrl = 'https://cdn.stape.io/dtag/' + dataScriptVersion + '.js';
+    injectScript(dataTagScriptUrl, sendPostRequest, data.gtmOnFailure, dataTagScriptUrl);
+  }
 } else {
   sendGetRequest();
 }
@@ -1333,6 +1319,45 @@ ___WEB_PERMISSIONS___
                     "boolean": true
                   }
                 ]
+              },
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "key"
+                  },
+                  {
+                    "type": 1,
+                    "string": "read"
+                  },
+                  {
+                    "type": 1,
+                    "string": "write"
+                  },
+                  {
+                    "type": 1,
+                    "string": "execute"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "loadDataTagScript"
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  }
+                ]
               }
             ]
           }
@@ -1379,6 +1404,13 @@ ___WEB_PERMISSIONS___
         "versionId": "1"
       },
       "param": [
+        {
+          "key": "allowedKeys",
+          "value": {
+            "type": 1,
+            "string": "specific"
+          }
+        },
         {
           "key": "keyPatterns",
           "value": {

--- a/template.tpl
+++ b/template.tpl
@@ -1405,13 +1405,6 @@ ___WEB_PERMISSIONS___
       },
       "param": [
         {
-          "key": "allowedKeys",
-          "value": {
-            "type": 1,
-            "string": "specific"
-          }
-        },
-        {
           "key": "keyPatterns",
           "value": {
             "type": 2,


### PR DESCRIPTION
Hi there.

It seems I haven't thought my last pull request through entirely. It worked but only because I forgot about a change I also made in my experiments earlier: Added additional allowed URL patterns to the inject_script permission of the template. So now at implementing the feature in another container I hat do realize that the change failed to fullfill the actual intention: 

**Use the Data Tag linked to the version from the gallery while still loading the correct version of the data-tag-script from a custom source**

So this is a pull request to support this case. My proposal is as follows

I introduced an option in the template that will make it load the data-script-tag (with the desired version) not using the gtm `injectScript` functionality, but a function that users have to have defined globally that can then be called using `callInWindow`. 

In order for this to work (so that `callInWindow` will allow the usage of this function), it needs to have a defined name (I used `loadDataTagScript`) and the permissions for `access_globals` need to include this name. 

The function is expected to take 3 parameters, the version of the script, a successCallback and an errorCallback. The successCallback or errorCallback should be called on every call of the function but it should be only attempted once to load the script.

For users that want to provide such a function I've added `data-tag-load.js` that can be used as content of a Custom HTML tag and adapted to use the desired url.

This way now users of Data Tag, if they want can remain linked to the gallery and still load the correct data tag script from their custom source.

I think current users of the Data Tag should not be affected by this change even if they used the lately introduced `load_data_tag_script_url` option. This is because in order for this to work they had to change permissions and therefore are detached from the gallery already.

Alex
 