### PR TITLE
Race conditions issue fix - Option 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+**/.DS_Store
 src/
 dtag.js
 node_modules/

--- a/data-tag.js
+++ b/data-tag.js
@@ -127,7 +127,7 @@ function dataTagSendData(data, gtmServerDomain, requestPath, dataLayerEventName,
                 })
                 .forEach(function(eventString) {
                   try {
-                    const event =  JSON.parse(eventString.replace('event: message\ndata: ', ''));
+                    var event = JSON.parse(eventString.replace('event: message\ndata: ', ''));
                     processResponseDataEvent(event);
                   } catch (error) {
                     console.error('Error processing response data:', error);
@@ -210,7 +210,62 @@ function dataTagSendData(data, gtmServerDomain, requestPath, dataLayerEventName,
     }
 }
 
-function dataTagGetData(containerId) {
+function dataTagGetData(containerId, eventId, useOwnDataModel, useOnlyCurrentEventObj) {
+    var dataLayerGTM = window.google_tag_manager[containerId].dataLayer;
+
+    var dataModelUntilCurrentEvent;
+    var currentEventObj;
+    if (
+      typeof eventId !== 'undefined' &&
+      (useOwnDataModel || useOnlyCurrentEventObj)
+    ) {
+      try {
+        var isObjectEmpty = function (obj) {
+          if (typeof obj !== 'object') return;
+          for (var key in obj) {
+            if (Object.prototype.hasOwnProperty.call(obj, key)) return false;
+          }
+          return true;
+        };
+
+        var dataLayerName = dataLayerGTM.name;
+        var actualDataLayer = window[dataLayerName];
+        var actualDataLayerLength = actualDataLayer.length;
+        for (var i = actualDataLayerLength - 1; i >= 0; i--) {
+          var obj = actualDataLayer[i];
+
+          if (!obj || typeof obj !== 'object') continue;
+
+          // DataLayer event from GTM template using createQueue() API
+          if (
+            !obj.hasOwnProperty('gtm.uniqueEventId') &&
+            typeof obj.getUntrustedMessageValue === 'function' &&
+            typeof obj.value === 'object'
+          ) {
+            obj = obj.value;
+          }
+
+          if (eventId === obj['gtm.uniqueEventId']) {
+            if (useOwnDataModel) {
+              dataModelUntilCurrentEvent = dataTagGetOwnDataModel(
+                actualDataLayer.slice(0, i + 1)
+              );
+              if (
+                typeof dataModelUntilCurrentEvent !== 'object' ||
+                isObjectEmpty(dataModelUntilCurrentEvent)
+              ) {
+                dataModelUntilCurrentEvent = null;
+              }
+            } else if (useOnlyCurrentEventObj) {
+              currentEventObj = obj;
+            }
+
+            break;
+          }
+        }
+      } catch (e) {}
+    }
+
     window.dataTagData = {
         document: {
             characterSet: window.document.characterSet,
@@ -221,14 +276,200 @@ function dataTagGetData(containerId) {
             width: window.screen.width,
             height: window.screen.height,
         },
-        dataModel: window.google_tag_manager[containerId].dataLayer.get({
-            split: function() { return []; }
-        }),
+        dataModel: dataModelUntilCurrentEvent || currentEventObj || dataLayerGTM.get({ split: function() { return []; } })
     };
 
     return window.dataTagData;
 }
 
+function dataTagGetOwnDataModel(dataLayerArray) {
+  try {
+    var dataModel = {};
+
+    var typesRegex =
+      /\[object (Boolean|Number|String|Function|Array|Date|RegExp)\]/;
+    var getValueType = function (a) {
+      if (a == null) return String(a);
+      var b = typesRegex.exec(Object.prototype.toString.call(Object(a)));
+      return b ? b[1].toLowerCase() : 'object';
+    };
+
+    var hasOwnProperty = function (a, b) {
+      return Object.prototype.hasOwnProperty.call(Object(a), b);
+    };
+
+    var isString = function (a) {
+      return typeof a === 'string';
+    };
+
+    var isArguments = function (a) {
+      return (
+        !!a &&
+        (Object.prototype.toString.call(a) === '[object Arguments]' ||
+          Object.prototype.hasOwnProperty.call(a, 'callee'))
+      );
+    };
+
+    var isPlainObject = function (a) {
+      if (
+        !a ||
+        getValueType(a) != 'object' ||
+        a.nodeType ||
+        (a.window && a == a.window) ||
+        isArguments(a)
+      ) {
+        return !1;
+      }
+
+      try {
+        if (
+          a.constructor &&
+          !hasOwnProperty(a, 'constructor') &&
+          !hasOwnProperty(a.constructor.prototype, 'isPrototypeOf')
+        ) {
+          return !1;
+        }
+      } catch (c) {
+        return !1;
+      }
+      for (var b in a);
+      return b === void 0 || hasOwnProperty(a, b);
+    };
+
+    var recursiveMerge = function (a, b) {
+      var c = b || (getValueType(a) == 'array' ? [] : {}),
+        d;
+      for (d in a) {
+        if (d === '__proto__' || d === 'constructor' || d === 'prototype') {
+          continue;
+        }
+        if (hasOwnProperty(a, d)) {
+          var e = a[d];
+          if (getValueType(e) == 'array') {
+            getValueType(c[d]) != 'array' && (c[d] = []);
+            c[d] = recursiveMerge(e, c[d]);
+          } else if (isPlainObject(e)) {
+            isPlainObject(c[d]) || (c[d] = {});
+            c[d] = recursiveMerge(e, c[d]);
+          } else {
+            c[d] = e;
+          }
+        }
+      }
+      return c;
+    };
+
+    var cloneObject = function (a) {
+      if (getValueType(a) == 'array' || isPlainObject(a)) {
+        return recursiveMerge(a, null);
+      }
+      return a;
+    };
+
+    var convertDotNotationToNestedObject = function (a, b) {
+      var c = {},
+        d = c,
+        e = a.split('.'),
+        f = 0;
+      for (f = 0; f < e.length - 1; f++) {
+        d = d[e[f]] = {};
+      }
+      d[e[e.length - 1]] = b;
+      return c;
+    };
+
+    if (!Array.isArray(dataLayerArray)) return;
+
+    for (var i = 0; i < dataLayerArray.length; i++) {
+      delete dataModel.eventModel;
+
+      var item = dataLayerArray[i];
+      var isGtagCommand = false;
+
+      if (isArguments(item)) {
+        var command = item[0];
+        var processedItem = null;
+
+        if (command === 'js' && item.length >= 2 && item[1].getTime) {
+          processedItem = {
+            event: 'gtm.js',
+            'gtm.start': item[1].getTime()
+          };
+        } else if (command === 'set') {
+          if (item.length === 2 && isPlainObject(item[1])) {
+            processedItem = cloneObject(item[1]);
+          } else if (item.length === 3 && isString(item[1])) {
+            processedItem = {};
+            var valueToSet = item[2];
+            if (
+              isPlainObject(valueToSet) ||
+              getValueType(valueToSet) == 'array'
+            ) {
+              processedItem[item[1]] = cloneObject(valueToSet);
+            } else {
+              processedItem[item[1]] = valueToSet;
+            }
+          }
+        } else if (
+          command === 'event' &&
+          item.length >= 2 &&
+          isString(item[1])
+        ) {
+          var eventParams =
+            item.length > 2 && isPlainObject(item[2])
+              ? cloneObject(item[2])
+              : {};
+          processedItem = {
+            event: item[1],
+            eventModel: eventParams
+          };
+        }
+
+        if (processedItem) {
+          if (item['gtm.uniqueEventId']) {
+            processedItem['gtm.uniqueEventId'] = item['gtm.uniqueEventId'];
+          }
+          isGtagCommand = true;
+          item = processedItem;
+        }
+      }
+
+      // DataLayer event from GTM template using createQueue() API
+      if (
+        item &&
+        typeof item === 'object' &&
+        typeof item.getUntrustedMessageValue === 'function' &&
+        typeof item.value === 'object'
+      ) {
+        item = item.value;
+      }
+
+      if (!isPlainObject(item)) continue;
+
+      var shouldClear = isGtagCommand || !!item._clear;
+      for (var key in item) {
+        if (hasOwnProperty(item, key) && key !== '_clear') {
+          if (shouldClear) {
+            var clearObject = convertDotNotationToNestedObject(
+              key,
+              undefined
+            );
+            recursiveMerge(clearObject, dataModel);
+          }
+          var newNestedObject = convertDotNotationToNestedObject(
+            key,
+            item[key]
+          );
+          recursiveMerge(newNestedObject, dataModel);
+        }
+      }
+
+    }
+    return dataModel;
+  } catch (e) {}
+}
+
+// prettier-ignore
 function dataTagMD5(inputString) {
     var hc="0123456789abcdef";
     function rh(n) {var j,s="";for(j=0;j<=3;j++) s+=hc.charAt((n>>(j*8+4))&0x0F)+hc.charAt((n>>(j*8))&0x0F);return s;}
@@ -272,6 +513,7 @@ function dataTagMD5(inputString) {
     return rh(a)+rh(b)+rh(c)+rh(d);
 }
 
+// prettier-ignore
 !function(t,r){(t="undefined"!=typeof globalThis?globalThis:t||self).dataTagJsSHA=r()}(this,(function(){"use strict";var t=function(r,n){return(t=Object.setPrototypeOf||{__proto__:[]}instanceof Array&&function(t,r){t.__proto__=r}||function(t,r){for(var n in r)Object.prototype.hasOwnProperty.call(r,n)&&(t[n]=r[n])})(r,n)};var r="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";function n(t,r,n,i){var e,o,u,s=r||[0],f=(n=n||0)>>>3,h=-1===i?3:0;for(e=0;e<t.length;e+=1)o=(u=e+f)>>>2,s.length<=o&&s.push(0),s[o]|=t[e]<<8*(h+i*(u%4));return{value:s,binLen:8*t.length+n}}function i(t,i,e){switch(i){case"UTF8":case"UTF16BE":case"UTF16LE":break;default:throw new Error("encoding must be UTF8, UTF16BE, or UTF16LE")}switch(t){case"HEX":return function(t,r,n){return function(t,r,n,i){var e,o,u,s;if(0!=t.length%2)throw new Error("String of HEX type must be in byte increments");var f=r||[0],h=(n=n||0)>>>3,a=-1===i?3:0;for(e=0;e<t.length;e+=2){if(o=parseInt(t.substr(e,2),16),isNaN(o))throw new Error("String of HEX type contains invalid characters");for(u=(s=(e>>>1)+h)>>>2;f.length<=u;)f.push(0);f[u]|=o<<8*(a+i*(s%4))}return{value:f,binLen:4*t.length+n}}(t,r,n,e)};case"TEXT":return function(t,r,n){return function(t,r,n,i,e){var o,u,s,f,h,a,c,w,v=0,E=n||[0],A=(i=i||0)>>>3;if("UTF8"===r)for(c=-1===e?3:0,s=0;s<t.length;s+=1)for(u=[],128>(o=t.charCodeAt(s))?u.push(o):2048>o?(u.push(192|o>>>6),u.push(128|63&o)):55296>o||57344<=o?u.push(224|o>>>12,128|o>>>6&63,128|63&o):(s+=1,o=65536+((1023&o)<<10|1023&t.charCodeAt(s)),u.push(240|o>>>18,128|o>>>12&63,128|o>>>6&63,128|63&o)),f=0;f<u.length;f+=1){for(h=(a=v+A)>>>2;E.length<=h;)E.push(0);E[h]|=u[f]<<8*(c+e*(a%4)),v+=1}else for(c=-1===e?2:0,w="UTF16LE"===r&&1!==e||"UTF16LE"!==r&&1===e,s=0;s<t.length;s+=1){for(o=t.charCodeAt(s),!0===w&&(o=(f=255&o)<<8|o>>>8),h=(a=v+A)>>>2;E.length<=h;)E.push(0);E[h]|=o<<8*(c+e*(a%4)),v+=2}return{value:E,binLen:8*v+i}}(t,i,r,n,e)};case"B64":return function(t,n,i){return function(t,n,i,e){var o,u,s,f,h,a,c=0,w=n||[0],v=(i=i||0)>>>3,E=-1===e?3:0,A=t.indexOf("=");if(-1===t.search(/^[a-zA-Z0-9=+/]+$/))throw new Error("Invalid character in base-64 string");if(t=t.replace(/=/g,""),-1!==A&&A<t.length)throw new Error("Invalid '=' found in base-64 string");for(o=0;o<t.length;o+=4){for(f=t.substr(o,4),s=0,u=0;u<f.length;u+=1)s|=r.indexOf(f.charAt(u))<<18-6*u;for(u=0;u<f.length-1;u+=1){for(h=(a=c+v)>>>2;w.length<=h;)w.push(0);w[h]|=(s>>>16-8*u&255)<<8*(E+e*(a%4)),c+=1}}return{value:w,binLen:8*c+i}}(t,n,i,e)};case"BYTES":return function(t,r,n){return function(t,r,n,i){var e,o,u,s,f=r||[0],h=(n=n||0)>>>3,a=-1===i?3:0;for(o=0;o<t.length;o+=1)e=t.charCodeAt(o),u=(s=o+h)>>>2,f.length<=u&&f.push(0),f[u]|=e<<8*(a+i*(s%4));return{value:f,binLen:8*t.length+n}}(t,r,n,e)};case"ARRAYBUFFER":try{new ArrayBuffer(0)}catch(t){throw new Error("ARRAYBUFFER not supported by this environment")}return function(t,r,i){return function(t,r,i,e){return n(new Uint8Array(t),r,i,e)}(t,r,i,e)};case"UINT8ARRAY":try{new Uint8Array(0)}catch(t){throw new Error("UINT8ARRAY not supported by this environment")}return function(t,r,i){return n(t,r,i,e)};default:throw new Error("format must be HEX, TEXT, B64, BYTES, ARRAYBUFFER, or UINT8ARRAY")}}function e(t,n,i,e){switch(t){case"HEX":return function(t){return function(t,r,n,i){var e,o,u="",s=r/8,f=-1===n?3:0;for(e=0;e<s;e+=1)o=t[e>>>2]>>>8*(f+n*(e%4)),u+="0123456789abcdef".charAt(o>>>4&15)+"0123456789abcdef".charAt(15&o);return i.outputUpper?u.toUpperCase():u}(t,n,i,e)};case"B64":return function(t){return function(t,n,i,e){var o,u,s,f,h,a="",c=n/8,w=-1===i?3:0;for(o=0;o<c;o+=3)for(f=o+1<c?t[o+1>>>2]:0,h=o+2<c?t[o+2>>>2]:0,s=(t[o>>>2]>>>8*(w+i*(o%4))&255)<<16|(f>>>8*(w+i*((o+1)%4))&255)<<8|h>>>8*(w+i*((o+2)%4))&255,u=0;u<4;u+=1)a+=8*o+6*u<=n?r.charAt(s>>>6*(3-u)&63):e.b64Pad;return a}(t,n,i,e)};case"BYTES":return function(t){return function(t,r,n){var i,e,o="",u=r/8,s=-1===n?3:0;for(i=0;i<u;i+=1)e=t[i>>>2]>>>8*(s+n*(i%4))&255,o+=String.fromCharCode(e);return o}(t,n,i)};case"ARRAYBUFFER":try{new ArrayBuffer(0)}catch(t){throw new Error("ARRAYBUFFER not supported by this environment")}return function(t){return function(t,r,n){var i,e=r/8,o=new ArrayBuffer(e),u=new Uint8Array(o),s=-1===n?3:0;for(i=0;i<e;i+=1)u[i]=t[i>>>2]>>>8*(s+n*(i%4))&255;return o}(t,n,i)};case"UINT8ARRAY":try{new Uint8Array(0)}catch(t){throw new Error("UINT8ARRAY not supported by this environment")}return function(t){return function(t,r,n){var i,e=r/8,o=-1===n?3:0,u=new Uint8Array(e);for(i=0;i<e;i+=1)u[i]=t[i>>>2]>>>8*(o+n*(i%4))&255;return u}(t,n,i)};default:throw new Error("format must be HEX, B64, BYTES, ARRAYBUFFER, or UINT8ARRAY")}}var o=[1116352408,1899447441,3049323471,3921009573,961987163,1508970993,2453635748,2870763221,3624381080,310598401,607225278,1426881987,1925078388,2162078206,2614888103,3248222580,3835390401,4022224774,264347078,604807628,770255983,1249150122,1555081692,1996064986,2554220882,2821834349,2952996808,3210313671,3336571891,3584528711,113926993,338241895,666307205,773529912,1294757372,1396182291,1695183700,1986661051,2177026350,2456956037,2730485921,2820302411,3259730800,3345764771,3516065817,3600352804,4094571909,275423344,430227734,506948616,659060556,883997877,958139571,1322822218,1537002063,1747873779,1955562222,2024104815,2227730452,2361852424,2428436474,2756734187,3204031479,3329325298],u=[3238371032,914150663,812702999,4144912697,4290775857,1750603025,1694076839,3204075428],s=[1779033703,3144134277,1013904242,2773480762,1359893119,2600822924,528734635,1541459225];function f(t){var r={outputUpper:!1,b64Pad:"=",outputLen:-1},n=t||{},i="Output length must be a multiple of 8";if(r.outputUpper=n.outputUpper||!1,n.b64Pad&&(r.b64Pad=n.b64Pad),n.outputLen){if(n.outputLen%8!=0)throw new Error(i);r.outputLen=n.outputLen}else if(n.shakeLen){if(n.shakeLen%8!=0)throw new Error(i);r.outputLen=n.shakeLen}if("boolean"!=typeof r.outputUpper)throw new Error("Invalid outputUpper formatting option");if("string"!=typeof r.b64Pad)throw new Error("Invalid b64Pad formatting option");return r}function h(t,r){return t>>>r|t<<32-r}function a(t,r){return t>>>r}function c(t,r,n){return t&r^~t&n}function w(t,r,n){return t&r^t&n^r&n}function v(t){return h(t,2)^h(t,13)^h(t,22)}function E(t,r){var n=(65535&t)+(65535&r);return(65535&(t>>>16)+(r>>>16)+(n>>>16))<<16|65535&n}function A(t,r,n,i){var e=(65535&t)+(65535&r)+(65535&n)+(65535&i);return(65535&(t>>>16)+(r>>>16)+(n>>>16)+(i>>>16)+(e>>>16))<<16|65535&e}function p(t,r,n,i,e){var o=(65535&t)+(65535&r)+(65535&n)+(65535&i)+(65535&e);return(65535&(t>>>16)+(r>>>16)+(n>>>16)+(i>>>16)+(e>>>16)+(o>>>16))<<16|65535&o}function d(t){return h(t,7)^h(t,18)^a(t,3)}function l(t){return h(t,6)^h(t,11)^h(t,25)}function R(t){return"SHA-224"==t?u.slice():s.slice()}function y(t,r){var n,i,e,u,s,f,R,y,U,b,T,m,F=[];for(n=r[0],i=r[1],e=r[2],u=r[3],s=r[4],f=r[5],R=r[6],y=r[7],T=0;T<64;T+=1)F[T]=T<16?t[T]:A(h(m=F[T-2],17)^h(m,19)^a(m,10),F[T-7],d(F[T-15]),F[T-16]),U=p(y,l(s),c(s,f,R),o[T],F[T]),b=E(v(n),w(n,i,e)),y=R,R=f,f=s,s=E(u,U),u=e,e=i,i=n,n=E(U,b);return r[0]=E(n,r[0]),r[1]=E(i,r[1]),r[2]=E(e,r[2]),r[3]=E(u,r[3]),r[4]=E(s,r[4]),r[5]=E(f,r[5]),r[6]=E(R,r[6]),r[7]=E(y,r[7]),r}return function(r){function n(t,n,e){var o=this;if("SHA-224"!==t&&"SHA-256"!==t)throw new Error("Chosen SHA variant is not supported");var u=e||{};return(o=r.call(this,t,n,e)||this).t=o.i,o.o=!0,o.u=-1,o.s=i(o.h,o.v,o.u),o.A=y,o.p=function(t){return t.slice()},o.l=R,o.R=function(r,n,i,e){return function(t,r,n,i,e){for(var o,u=15+(r+65>>>9<<4),s=r+n;t.length<=u;)t.push(0);for(t[r>>>5]|=128<<24-r%32,t[u]=4294967295&s,t[u-1]=s/4294967296|0,o=0;o<t.length;o+=16)i=y(t.slice(o,o+16),i);return"SHA-224"===e?[i[0],i[1],i[2],i[3],i[4],i[5],i[6]]:i}(r,n,i,e,t)},o.U=R(t),o.T=512,o.m="SHA-224"===t?224:256,o.F=!1,u.hmacKey&&o.B(function(t,r,n,e){var o=t+" must include a value and format";if(!r){if(!e)throw new Error(o);return e}if(void 0===r.value||!r.format)throw new Error(o);return i(r.format,r.encoding||"UTF8",n)(r.value)}("hmacKey",u.hmacKey,o.u)),o}return function(r,n){function i(){this.constructor=r}t(r,n),r.prototype=null===n?Object.create(n):(i.prototype=n.prototype,new i)}(n,r),n}(function(){function t(t,r,n){var i=n||{};if(this.h=r,this.v=i.encoding||"UTF8",this.numRounds=i.numRounds||1,isNaN(this.numRounds)||this.numRounds!==parseInt(this.numRounds,10)||1>this.numRounds)throw new Error("numRounds must a integer >= 1");this.g=t,this.Y=[],this.H=0,this.S=!1,this.I=0,this.C=!1,this.L=[],this.N=[]}return t.prototype.update=function(t){var r,n=0,i=this.T>>>5,e=this.s(t,this.Y,this.H),o=e.binLen,u=e.value,s=o>>>5;for(r=0;r<s;r+=i)n+this.T<=o&&(this.U=this.A(u.slice(r,r+i),this.U),n+=this.T);this.I+=n,this.Y=u.slice(n>>>5),this.H=o%this.T,this.S=!0},t.prototype.getHash=function(t,r){var n,i,o=this.m,u=f(r);if(this.F){if(-1===u.outputLen)throw new Error("Output length must be specified in options");o=u.outputLen}var s=e(t,o,this.u,u);if(this.C&&this.t)return s(this.t(u));for(i=this.R(this.Y.slice(),this.H,this.I,this.p(this.U),o),n=1;n<this.numRounds;n+=1)this.F&&o%32!=0&&(i[i.length-1]&=16777215>>>24-o%32),i=this.R(i,o,0,this.l(this.g),o);return s(i)},t.prototype.setHMACKey=function(t,r,n){if(!this.o)throw new Error("Variant does not support HMAC");if(this.S)throw new Error("Cannot set MAC key after calling update");var e=i(r,(n||{}).encoding||"UTF8",this.u);this.B(e(t))},t.prototype.B=function(t){var r,n=this.T>>>3,i=n/4-1;if(1!==this.numRounds)throw new Error("Cannot set numRounds with MAC");if(this.C)throw new Error("MAC key already set");for(n<t.binLen/8&&(t.value=this.R(t.value,t.binLen,0,this.l(this.g),this.m));t.value.length<=i;)t.value.push(0);for(r=0;r<=i;r+=1)this.L[r]=909522486^t.value[r],this.N[r]=1549556828^t.value[r];this.U=this.A(this.L,this.U),this.I=this.T,this.C=!0},t.prototype.getHMAC=function(t,r){var n=f(r);return e(t,this.m,this.u,n)(this.i())},t.prototype.i=function(){var t;if(!this.C)throw new Error("Cannot call getHMAC without first setting MAC key");var r=this.R(this.Y.slice(),this.H,this.I,this.p(this.U),this.m);return t=this.A(this.N,this.l(this.g)),t=this.R(r,this.m,this.T,t,this.m)},t}())}));
 
 function dataTag256(inputString, type) {

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
-homepage: "https://stape.io/"
-documentation: "https://github.com/stape-io/data-tag"
+homepage: 'https://stape.io/'
+documentation: 'https://github.com/stape-io/data-tag'
 versions:
+  - sha: da99b1a9696a3eebe9f20a624ff15b1373b2ca0e
+    changeNotes: Fixed the race condition issue affecting the 'Send all from DataLayer' feature.
   - sha: 7b7305d40e9666c737f3f9a5550b427c5e28b726
     changeNotes: Added common cookie support for Google Advertising platforms.
   - sha: a0aececc652374243dc1018dc83f31cb7dd6d41e

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 homepage: 'https://stape.io/'
 documentation: 'https://github.com/stape-io/data-tag'
 versions:
-  - sha: da99b1a9696a3eebe9f20a624ff15b1373b2ca0e
+  - sha: 2a03cb07ab47c9614c6e1314fda5358000197cae
     changeNotes: Fixed the race condition issue affecting the 'Send all from DataLayer' feature.
   - sha: 7b7305d40e9666c737f3f9a5550b427c5e28b726
     changeNotes: Added common cookie support for Google Advertising platforms.


### PR DESCRIPTION
This PR **totally solves** the issues https://github.com/stape-io/data-tag/issues/28 and https://community.stape.io/t/data-tag-client-property-pollution-across-events/3425/15, and is an alternative and better option to the PR https://github.com/stape-io/data-tag/pull/33.

---

Solution that covers **all problematic** scenarios described in https://github.com/stape-io/data-tag/issues/28 and https://community.stape.io/t/data-tag-client-property-pollution-across-events/3425/15.

**Description of the problem and why it happens:**

The ideal scenario would be the tag accessing the data model immediately when it runs, not from inside the `injectScript` success handler. However, access to the data model (`window.dataTagGetData.dataModel`) is only available **after** loading an external script because it's not possible to directly access some things in the global scope through GTM templates.

However, GTM wraps the `injectScript` success/failure handlers in `setTimeout(handler, 0)`, deferring their execution to the next event loop cycle. This delays data model access, making it too late to capture the correct state from the triggering data layer push.

Note: the `Send all from DataLayer` option collects the **GTM dataModel**, **not the actual dataLayer object** of when the tag fired (which can be different due to async operations).
Learn more: [[1]](https://www.simoahava.com/analytics/google-tag-manager-data-model/) and [[2]](https://www.simoahava.com/analytics/two-simple-data-model-tricks/#trick-2-get-the-object-representation-of-the-current-state-of-the-data-model).

**Solutions:**

- A flag in `window` prevents `injectScript()` from running again after the script has loaded, avoiding repeated `setTimeout` executions. This flag is actually a flag for each script URL, to account for scenarios where multiple GTMs are executing the Data Tag (with or without the same script URL). [[1]](https://github.com/stape-io/data-tag/pull/41/files#diff-4cae99d1fcdb3624d25cd68a3151a48e7d6b3bc1047c61bff8fe3cde95917210R50-R67)
- The `dataTagGetData` global function from `data-tag.js` now accepts 3 new arguments: `Event ID`, a flag `Use Own Data Model` and a flag `Use only current data layer event object`. The `Use Own Data Model` flag, when enabled, recreates the `dataModel` **manually** by replicating what GTM does under the hood, and it doesn't use the native `dataModel` value from GTM ([as suggested here](https://github.com/stape-io/data-tag/issues/28#issuecomment-3108814666)). And the `Use only current data layer event object`, if enabled, only uses the data layer event that triggered the tag.
[[1]](https://github.com/stape-io/data-tag/pull/41/files#diff-292fc4038a31ca33dc6273a206bd11177f6bc3742959d27c4ef5f9f23e83948eR217-R242) [[2]](https://github.com/stape-io/data-tag/pull/41/changes#diff-292fc4038a31ca33dc6273a206bd11177f6bc3742959d27c4ef5f9f23e83948eR213-R268) [[3]](https://github.com/stape-io/data-tag/pull/41/changes#diff-292fc4038a31ca33dc6273a206bd11177f6bc3742959d27c4ef5f9f23e83948eR279).
- The Event ID is saved in the tag’s global context **before** the `injectScript` handler runs, ensuring it's available to `sendPostRequest()`, and is passed to the `dataTagGetData` global function from `data-tag.js` to be used to locate the actual data layer event that triggered the tag, and then build the `dataModel` manually. This follows the [same idea proposed here](https://github.com/stape-io/data-tag/issues/28#issuecomment-2560731767), but adjusts timing and placement. [[1]](https://github.com/stape-io/data-tag/pull/41/changes#diff-4cae99d1fcdb3624d25cd68a3151a48e7d6b3bc1047c61bff8fe3cde95917210R40) [[2]](https://github.com/stape-io/data-tag/pull/41/changes#diff-4cae99d1fcdb3624d25cd68a3151a48e7d6b3bc1047c61bff8fe3cde95917210R224)
